### PR TITLE
Ignore .idea/ from Rider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,4 +85,7 @@ TSOClient/tso.client/GlobalSettings1.Designer.cs
 TSOClient/.vs/config/applicationhost.config
 *.nvuser
 
+# Rider IDE
+.idea/
+
 TSOClient/Mario


### PR DESCRIPTION
Added .idea/ directory to .gitignore to prevent JetBrains Rider IDE files from being tracked in the repository.